### PR TITLE
Provide end-of-day information as a dictionary and decode umlauts

### DIFF
--- a/ecrterm/ecr.py
+++ b/ecrterm/ecr.py
@@ -151,7 +151,6 @@ class ECR(object):
             self.transport = SocketTransport(uri=device)
         # This turns on debug logging
         # self.transport.slog = ecr_log
-        self.eod_info = None
         self.daylog = []
         self.daylog_template = ''
         self.history = []
@@ -233,7 +232,6 @@ class ECR(object):
         """
         - sends an end of day packet.
         - saves the log in `daylog`
-        - saves information dictionary in `eod_info`
 
         @returns: 0 if there were no protocol errors.
         """
@@ -249,10 +247,9 @@ class ECR(object):
 
         if not self.daylog:
             # there seems to be no printout. we search in statusinformation.
-            self.eod_info = self._end_of_day_info_packet()
-            # FIXME: The following should not happen inside the library!
+            eod_info = self._end_of_day_info_packet()
             try:
-                self.daylog = (self.daylog_template % self.eod_info).split('\n')
+                self.daylog = (self.daylog_template % eod_info).split('\n')
             except Exception:
                 import traceback
                 traceback.print_exc()

--- a/ecrterm/ecr.py
+++ b/ecrterm/ecr.py
@@ -151,6 +151,7 @@ class ECR(object):
             self.transport = SocketTransport(uri=device)
         # This turns on debug logging
         # self.transport.slog = ecr_log
+        self.eod_info = None
         self.daylog = []
         self.daylog_template = ''
         self.history = []
@@ -232,6 +233,7 @@ class ECR(object):
         """
         - sends an end of day packet.
         - saves the log in `daylog`
+        - saves information dictionary in `eod_info`
 
         @returns: 0 if there were no protocol errors.
         """
@@ -247,9 +249,10 @@ class ECR(object):
 
         if not self.daylog:
             # there seems to be no printout. we search in statusinformation.
-            eod_info = self._end_of_day_info_packet()
+            self.eod_info = self._end_of_day_info_packet()
+            # FIXME: The following should not happen inside the library!
             try:
-                self.daylog = (self.daylog_template % eod_info).split('\n')
+                self.daylog = (self.daylog_template % self.eod_info).split('\n')
             except Exception:
                 import traceback
                 traceback.print_exc()

--- a/ecrterm/packets/base_packets.py
+++ b/ecrterm/packets/base_packets.py
@@ -585,7 +585,7 @@ class PrintLine(Packet):
     def consume_fixed(self, data, length):
         if length:
             self.fixed_values['attribute'] = int(data[0])  # attribute 1 byte
-            self.fixed_values['text'] = ''.join([chr(i) for i in data[1:]])
+            self.fixed_values['text'] = ''.join(bytes([i for i in data[1:]]).decode('cp437'))
             return []
         return []
 


### PR DESCRIPTION
I'm new to this library and I want to include it in my python based cash register. Before I start implementing, I have had a look at the library and the test script. 

First, from my point of view, I would appreciate if the library would give the information to the program as a dictionary instead of requiring a template and rendering it internally. When I have the dict, I can choose which fields to display and which not based upon if there is data inside. I implemented this for the end of day summary and I will try to achieve something similar for the receipt of a payment but this is not included here.

Second, my payment terminal sends data encoded in CP437 and I did not find a way to change this, so possibly this is what all Ingenico devices do. The library used to interpred received text with "chr()" and so the numbers are used as unicode code points. I don't know how other terminals work but I think Unicode is not correct. So I changed this to interpret it as bytes and decode is with CP437 code page. So I get the data as string list with correct umlauts. As The strings "Händlerbeleg" and "gültig bis" contains umlauts, all receipts were messed up before.