### PR TITLE
Provide Reversal packet type and revert() method

### DIFF
--- a/ecrterm/ecr.py
+++ b/ecrterm/ecr.py
@@ -307,7 +307,6 @@ class ECR(object):
             logger.error("transmit error?")
         return False
 
-
     def partialcancellation(self, receipt=None, amount_cent=50, listener=None):
         """
         executes a preauthorisation in amount of cents.
@@ -359,7 +358,6 @@ class ECR(object):
         """Log off the PT."""
         self._state_registered = False
         return self.transmit(LogOff())
-    
 
     def show_text(self, lines=None, duration=5, beeps=0):
         """

--- a/ecrterm/packets/base_packets.py
+++ b/ecrterm/packets/base_packets.py
@@ -387,8 +387,9 @@ class Reversal(CommandWithPassword):
     wait_for_completion = True
 
     ALLOWED_BITMAPS = [
-        'receipt', 'amount', 'currency_code', 'status_byte', 'track_1', 'card_expire',
-        'card_number', 'track_2', 'track_3', 'additional', 'tlv']
+        'receipt', 'amount', 'currency_code', 'status_byte', 'track_1',
+        'card_expire', 'card_number', 'track_2', 'track_3', 'additional',
+        'tlv']
 
 
 class PreAuthorisation(Packet):

--- a/ecrterm/packets/base_packets.py
+++ b/ecrterm/packets/base_packets.py
@@ -377,6 +377,20 @@ class Authorisation(Packet):
         'pump_nr', 'cvv', 'additional', 'card_type', 'tlv']
 
 
+class Reversal(CommandWithPassword):
+    """
+    06 30
+    Reverse a payment
+    """
+    CMD_CLASS = 0x06
+    CMD_INSTR = 0x30
+    wait_for_completion = True
+
+    ALLOWED_BITMAPS = [
+        'receipt', 'amount', 'currency_code', 'status_byte', 'track_1', 'card_expire',
+        'card_number', 'track_2', 'track_3', 'additional', 'tlv']
+
+
 class PreAuthorisation(Packet):
     """
     06 22


### PR DESCRIPTION
Allow for reversal of payments. Works with the receipt number (in opposite to the "Trace-Nr" asked by the terminal itself for reversal).

This code is only tested with a proof-of-concept example script by myself. I was able to issue a payment and revert it quite after.